### PR TITLE
sock.close() can be called without declaring

### DIFF
--- a/modules/sipflood.py
+++ b/modules/sipflood.py
@@ -280,5 +280,9 @@ class SipFlood:
 
             sock.close()
 
-        sock.close()
+        try:
+            sock.close()
+        except NameError:
+            pass
+
         return


### PR DESCRIPTION
On sipflood there is a possibility to calling sock.close() without actual declaring.
(Happened with me with `-th 200 -n 1000`)
P.S: Not sure last `sock.close()` is needed before return.