### PR TITLE
Added "threads" argument to Invite argument parser

### DIFF
--- a/src/sippts/lib/params.py
+++ b/src/sippts/lib/params.py
@@ -2259,6 +2259,14 @@ Usage examples:
         default="",
     )
     other.add_argument(
+        "-th",
+        metavar="THREADS",
+        type=int,
+        help="Number of threads (default: 200)",
+        dest="threads",
+        default=200,
+    )
+    other.add_argument(
         "-local-ip",
         metavar="IP",
         type=str,


### PR DESCRIPTION
"threads/-th" argument wasn't correctly added to Invite argument parser so it was raising an exception when using "invite" option.
Block copied from "parser_exten".
AtributeError:
![imagen](https://github.com/user-attachments/assets/0dc33dc4-aabe-4ff0-9589-1bcc8c6183b9)
